### PR TITLE
Stop using the Python root logger

### DIFF
--- a/django_dbcache_fields/decorators.py
+++ b/django_dbcache_fields/decorators.py
@@ -9,7 +9,7 @@ from qualname import qualname
 
 from . import register
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class dbcache(object):

--- a/django_dbcache_fields/receivers.py
+++ b/django_dbcache_fields/receivers.py
@@ -8,7 +8,7 @@ from django.utils.module_loading import import_string
 from . import register
 from .utils import get_class_path, get_model_name
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def update_dbcache_fields(sender, instance, **kwargs):

--- a/django_dbcache_fields/utils.py
+++ b/django_dbcache_fields/utils.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import inspect
-import logging
-
-logger = logging.getLogger()
 
 
 class Register(object):


### PR DESCRIPTION
Makes it difficult to filter log messages originating from django-dbcache-fields.

Swap to using `__name__` for a module-based logger name (ie. `django_dbcache_fields.decorators` and `django_dbcache_fields.receivers`)

I also removed the unused logger in `utils.py`